### PR TITLE
Improve performance by decoding images only when necessary

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1569,6 +1569,7 @@ dependencies = [
  "glob",
  "thiserror",
  "tracing",
+ "zip",
 ]
 
 [[package]]
@@ -1581,6 +1582,7 @@ dependencies = [
  "thiserror",
  "tracing",
  "tracing-subscriber",
+ "zip",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -134,6 +134,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
+
+[[package]]
 name = "anstream"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -653,6 +659,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c59e92b5a388f549b863a7bea62612c09f24c8393560709a54558a9abdfb3b9c"
 
 [[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
 name = "cbc"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -723,6 +735,33 @@ dependencies = [
  "serde",
  "wasm-bindgen",
  "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "ciborium"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "effd91f6c78e5a4ace8a5d3c0b6bfaec9e2baaef55f3efc00e45fb2e477ee926"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdf919175532b369853f5d5e20b26b43112613fd6fe7aee757e35f7a44642656"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "defaa24ecc093c77630e6c15e17c51f5e187bf35ee514f4e2d67baaa96dae22b"
+dependencies = [
+ "ciborium-io",
+ "half 1.8.2",
 ]
 
 [[package]]
@@ -981,6 +1020,42 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b540bd8bc810d3885c6ea91e2018302f68baba2129ab3e88f32389ee9370880d"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "criterion"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
+dependencies = [
+ "anes",
+ "cast",
+ "ciborium",
+ "clap",
+ "criterion-plot",
+ "is-terminal",
+ "itertools",
+ "num-traits",
+ "once_cell",
+ "oorandom",
+ "plotters",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
+dependencies = [
+ "cast",
+ "itertools",
 ]
 
 [[package]]
@@ -1457,6 +1532,7 @@ version = "0.1.0"
 dependencies = [
  "camino",
  "chrono",
+ "criterion",
  "image",
  "sanitize-filename",
  "serde",
@@ -1733,7 +1809,7 @@ checksum = "832a761f35ab3e6664babfbdc6cef35a4860e816ec3916dcfd0882954e98a8a8"
 dependencies = [
  "bit_field",
  "flume",
- "half",
+ "half 2.2.1",
  "lebe",
  "miniz_oxide",
  "rayon-core",
@@ -2402,6 +2478,12 @@ dependencies = [
 
 [[package]]
 name = "half"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eabb4a44450da02c90444cf74558da904edde8fb4e9035a9a6a4e15445af0bd7"
+
+[[package]]
+name = "half"
 version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02b4af3693f1b705df946e9fe5631932443781d0aabb423b62fcd4d73f6d2fd0"
@@ -2598,7 +2680,7 @@ dependencies = [
  "bitflags 1.3.2",
  "bytemuck",
  "glam",
- "half",
+ "half 2.2.1",
  "iced_core",
  "image",
  "kamadak-exif",
@@ -2845,6 +2927,17 @@ dependencies = [
  "hermit-abi",
  "libc",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "is-terminal"
+version = "0.4.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bad00257d07be169d870ab665980b06cdb366d792ad690bf2e76876dc503455"
+dependencies = [
+ "hermit-abi",
+ "rustix 0.38.24",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3628,6 +3721,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
 
 [[package]]
+name = "oorandom"
+version = "11.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575"
+
+[[package]]
 name = "orbclient"
 version = "0.3.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4012,6 +4111,34 @@ name = "pkg-config"
 version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26072860ba924cbfa98ea39c8c19b4dd6a4a25423dbdf219c1eca91aa0cf6964"
+
+[[package]]
+name = "plotters"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2c224ba00d7cadd4d5c660deaf2098e5e80e07846537c51f9cfa4be50c1fd45"
+dependencies = [
+ "num-traits",
+ "plotters-backend",
+ "plotters-svg",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "plotters-backend"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e76628b4d3a7581389a35d5b6e2139607ad7c75b17aed325f210aa91f4a9609"
+
+[[package]]
+name = "plotters-svg"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38f6d39893cca0701371e3c27294f09797214b86f1fb951b89ade8ec04e2abab"
+dependencies = [
+ "plotters-backend",
+]
 
 [[package]]
 name = "png"
@@ -5169,6 +5296,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "tinyvec"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6084,6 +6221,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.0",
+]
+
+[[package]]
 name = "windows-targets"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6114,6 +6260,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-targets"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a18201040b24831fbb9e4eb208f8892e1f50a37feb53cc7ff887feb8f50e7cd"
+dependencies = [
+ "windows_aarch64_gnullvm 0.52.0",
+ "windows_aarch64_msvc 0.52.0",
+ "windows_i686_gnu 0.52.0",
+ "windows_i686_msvc 0.52.0",
+ "windows_x86_64_gnu 0.52.0",
+ "windows_x86_64_gnullvm 0.52.0",
+ "windows_x86_64_msvc 0.52.0",
+]
+
+[[package]]
 name = "windows-tokens"
 version = "0.44.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6132,6 +6293,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7764e35d4db8a7921e09562a0304bf2f93e0a51bfccee0bd0bb0b666b015ea"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6142,6 +6309,12 @@ name = "windows_aarch64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbaa0368d4f1d2aaefc55b6fcfee13f41544ddf36801e793edbbfd7d7df075ef"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -6156,6 +6329,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a28637cb1fa3560a16915793afb20081aba2c92ee8af57b4d5f28e4b3e7df313"
+
+[[package]]
 name = "windows_i686_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6166,6 +6345,12 @@ name = "windows_i686_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffe5e8e31046ce6230cc7215707b816e339ff4d4d67c65dffa206fd0f7aa7b9a"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -6180,6 +6365,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d6fa32db2bc4a2f5abeacf2b69f7992cd09dca97498da74a151a3132c26befd"
+
+[[package]]
 name = "windows_x86_64_gnullvm"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6192,6 +6383,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a657e1e9d3f514745a572a6846d3c7aa7dbe1658c056ed9c3344c4109a6949e"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6202,6 +6399,12 @@ name = "windows_x86_64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dff9641d1cd4be8d1a070daf9e3773c5f67e78b4d9d42263020c057706765c04"
 
 [[package]]
 name = "winit"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ camino = "1.1.4"
 clap = { version = "4.3.5", features = ["derive"] }
 cli-table = "0.4.7"
 chrono = "0.4.31"
+criterion = { version = "0.5.1", features = ["html_reports"] }
 dark-light = "1.0.0"
 dialoguer = "0.10.4"
 dioxus = "0.4.0"

--- a/eco-cbz/Cargo.toml
+++ b/eco-cbz/Cargo.toml
@@ -16,6 +16,13 @@ thiserror.workspace = true
 tracing.workspace = true
 zip.workspace = true
 
+[dev-dependencies]
+criterion.workspace = true
+
 [features]
 default = []
 metadata = ["dep:chrono", "dep:serde", "dep:serde_json", "dep:serde_repr"]
+
+[[bench]]
+name = "image"
+harness = false

--- a/eco-cbz/benches/image.rs
+++ b/eco-cbz/benches/image.rs
@@ -1,0 +1,57 @@
+use std::{fs::File, io::Read};
+
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use eco_cbz::Image;
+use zip::{read::ZipFile, ZipArchive};
+
+static INDEX: usize = 1;
+
+fn try_from_bytes(bytes: &[u8]) {
+    Image::try_from_bytes(bytes).unwrap();
+}
+
+fn try_from_zip_file(file: ZipFile) {
+    Image::try_from_zip_file(file).unwrap();
+}
+
+fn try_into_bytes(bytes: &[u8]) {
+    let img = Image::try_from_bytes(bytes).unwrap();
+    img.try_into_bytes().unwrap();
+}
+
+fn criterion_benchmark(c: &mut Criterion) {
+    let test_file_path = std::env::current_dir().unwrap().join("../test.cbz");
+    if !test_file_path.exists() {
+        panic!("a test.cbz file must be present at the root of this project");
+    }
+
+    let mut zip = ZipArchive::new(File::open(test_file_path).unwrap()).unwrap();
+    let bytes = {
+        let mut file = zip.by_index(INDEX).unwrap();
+        let mut bytes = Vec::with_capacity(file.size() as usize);
+        file.read_to_end(&mut bytes).unwrap();
+        bytes
+    };
+
+    c.bench_function(&format!("try_from_bytes {INDEX}"), |b| {
+        b.iter(|| {
+            try_from_bytes(black_box(&bytes));
+        })
+    });
+
+    c.bench_function(&format!("try_from_zip_file {INDEX}"), |b| {
+        b.iter(|| {
+            let file = zip.by_index(INDEX).unwrap();
+            try_from_zip_file(black_box(file));
+        })
+    });
+
+    c.bench_function(&format!("try_into_bytes {INDEX}"), |b| {
+        b.iter(|| {
+            try_into_bytes(black_box(&bytes));
+        })
+    });
+}
+
+criterion_group!(benches, criterion_benchmark);
+criterion_main!(benches);

--- a/eco-cbz/src/cbz.rs
+++ b/eco-cbz/src/cbz.rs
@@ -238,10 +238,29 @@ where
     /// ## Errors
     ///
     /// Same behavior as `insert_with_extension_and_file_options`
-    #[allow(clippy::missing_panics_doc)]
     pub fn insert<R: BufRead + Seek>(&mut self, image: Image<R>) -> Result<()> {
-        let extension = image.format().extensions_str().first().unwrap();
+        let extension = image
+            .format()
+            .extensions_str()
+            .first()
+            .ok_or(Error::UnknownImageExtension)?;
         self.insert_with_extension_and_file_options(image, extension, FileOptions::default())
+    }
+
+    /// ## Errors
+    ///
+    /// Same behavior as `insert_with_extension_and_file_options`
+    pub fn insert_with_file_options<R: BufRead + Seek>(
+        &mut self,
+        image: Image<R>,
+        file_options: FileOptions,
+    ) -> Result<()> {
+        let extension = image
+            .format()
+            .extensions_str()
+            .first()
+            .ok_or(Error::UnknownImageExtension)?;
+        self.insert_with_extension_and_file_options(image, extension, file_options)
     }
 
     /// ## Errors
@@ -354,6 +373,7 @@ impl Writer<Cursor<Vec<u8>>> {
         let mut file = OpenOptions::new()
             .read(true)
             .write(true)
+            .truncate(true)
             .create(true)
             .open(
                 path.with_file_name(

--- a/eco-cbz/src/errors.rs
+++ b/eco-cbz/src/errors.rs
@@ -38,6 +38,9 @@ pub enum Error {
     #[error("unknown image format error")]
     UnknownImageFormat,
 
+    #[error("unknown image extension error")]
+    UnknownImageExtension,
+
     #[cfg(feature = "metadata")]
     #[error("metadata error: {0}")]
     MetadataFormat(#[from] serde_json::Error),

--- a/eco-cbz/src/errors.rs
+++ b/eco-cbz/src/errors.rs
@@ -35,6 +35,9 @@ pub enum Error {
     #[error("image error: {0}")]
     Image(#[from] image::ImageError),
 
+    #[error("unknown image format error")]
+    UnknownImageFormat,
+
     #[cfg(feature = "metadata")]
     #[error("metadata error: {0}")]
     MetadataFormat(#[from] serde_json::Error),

--- a/eco-convert/src/lib.rs
+++ b/eco-convert/src/lib.rs
@@ -53,6 +53,9 @@ pub struct ConvertOptions {
 
     /// Reading order
     pub reading_order: ReadingOrder,
+
+    /// If not provided the images are stored as is (fastest), value must be between 0-9
+    pub compression_level: Option<i32>,
 }
 
 #[allow(clippy::missing_errors_doc)]
@@ -70,6 +73,7 @@ pub fn convert(opts: ConvertOptions) -> Result<()> {
                 opts.blur,
                 opts.autosplit,
                 opts.reading_order,
+                opts.compression_level,
             )?
         }
         Format::Pdf => {
@@ -83,6 +87,7 @@ pub fn convert(opts: ConvertOptions) -> Result<()> {
                 opts.blur,
                 opts.autosplit,
                 opts.reading_order,
+                opts.compression_level,
             )?
         }
     };

--- a/eco-convert/src/mobi/tl_parser.rs
+++ b/eco-convert/src/mobi/tl_parser.rs
@@ -1,6 +1,4 @@
-use std::path::Path;
-
-use eco_cbz::image::Image;
+use eco_cbz::image::ImageBytes;
 use mobi::Mobi;
 use tl::{HTMLTag, ParserOptions, VDom};
 use tracing::{debug, error, warn};
@@ -10,8 +8,7 @@ use crate::{utils::base_32, Result};
 use super::MobiVersion;
 
 #[allow(clippy::missing_errors_doc)]
-pub fn convert_to_imgs(path: impl AsRef<Path>) -> Result<Vec<Image>> {
-    let mobi = Mobi::from_path(path)?;
+pub fn convert_to_imgs(mobi: &Mobi) -> Result<Vec<ImageBytes<'_>>> {
     // Or is it `gen_version`? Both were equal in all the files I tested.
     let version = MobiVersion::try_from(mobi.metadata.mobi.format_version)?;
     debug!("mobi version {version:#?}");

--- a/eco-merge/Cargo.toml
+++ b/eco-merge/Cargo.toml
@@ -10,3 +10,4 @@ eco-cbz.workspace = true
 glob.workspace = true
 thiserror.workspace = true
 tracing.workspace = true
+zip.workspace = true

--- a/eco-pack/Cargo.toml
+++ b/eco-pack/Cargo.toml
@@ -11,3 +11,4 @@ glob.workspace = true
 thiserror.workspace = true
 tracing.workspace = true
 tracing-subscriber.workspace = true
+zip.workspace = true

--- a/eco-view/src/lib.rs
+++ b/eco-view/src/lib.rs
@@ -117,7 +117,7 @@ pub struct AppProps {
     page_loaded_receiver: Cell<Option<mpsc::UnboundedReceiver<()>>>,
 }
 
-#[allow(clippy::ignored_unit_patterns, clippy::too_many_lines)]
+#[allow(clippy::too_many_lines)]
 fn App(cx: Scope<AppProps>) -> Element {
     let page_loaded_receiver = cx.props.page_loaded_receiver.replace(None);
     // Forces reactivity on page loaded

--- a/eco-view/src/measure.rs
+++ b/eco-view/src/measure.rs
@@ -10,7 +10,6 @@ pub enum Precision {
     S,
 }
 
-#[allow(unused)]
 pub struct Measure {
     label: String,
     start: std::time::Duration,
@@ -28,7 +27,6 @@ impl Clone for Measure {
 }
 
 impl Measure {
-    #[allow(unused)]
     #[must_use]
     /// ## Panics
     pub fn new(label: &str, precision: Precision) -> Self {

--- a/eco/src/main.rs
+++ b/eco/src/main.rs
@@ -62,6 +62,10 @@ enum Command {
         /// Reading order
         #[clap(long, default_value_t = ReadingOrder::Rtl)]
         reading_order: ReadingOrder,
+
+        /// If not provided the images are stored as is (fastest), value must be between 0-9
+        #[clap(long)]
+        compression_level: Option<i32>,
     },
     Merge {
         /// A glob that matches all the archive to merge
@@ -75,6 +79,10 @@ enum Command {
         /// The merged archive name
         #[clap(short, long)]
         name: String,
+
+        /// If not provided the images are stored as is (fastest), value must be between 0-9
+        #[clap(long)]
+        compression_level: Option<i32>,
     },
     Pack {
         /// A glob that matches all the files to pack
@@ -107,6 +115,10 @@ enum Command {
         /// Reading order
         #[clap(long, default_value_t = ReadingOrder::Rtl)]
         reading_order: ReadingOrder,
+
+        /// If not provided the images are stored as is (fastest), value must be between 0-9
+        #[clap(long)]
+        compression_level: Option<i32>,
     },
     View {
         /// The path to the e-book file to view
@@ -133,6 +145,7 @@ fn main() -> Result<()> {
             blur,
             autosplit,
             reading_order,
+            compression_level,
         } => eco_convert::convert(eco_convert::ConvertOptions {
             path,
             from: from.into(),
@@ -143,15 +156,18 @@ fn main() -> Result<()> {
             blur,
             autosplit,
             reading_order: reading_order.into(),
+            compression_level,
         })?,
         Command::Merge {
             archives_glob,
             outdir,
             name,
+            compression_level,
         } => eco_merge::merge(eco_merge::MergeOptions {
             archives_glob,
             outdir,
             name,
+            compression_level,
         })?,
         Command::Pack {
             files_descriptor,
@@ -162,6 +178,7 @@ fn main() -> Result<()> {
             blur,
             autosplit,
             reading_order,
+            compression_level,
         } => eco_pack::pack(eco_pack::PackOptions {
             files_descriptor,
             outdir,
@@ -171,6 +188,7 @@ fn main() -> Result<()> {
             blur,
             autosplit,
             reading_order: reading_order.into(),
+            compression_level,
         })?,
         Command::View { path, type_ } => eco_view::view(eco_view::ViewOptions {
             path,


### PR DESCRIPTION
Unfortunately the zip perf leaves a bit to be desired, we should use [libdeflater](https://docs.rs/libdeflater/latest/libdeflater/) when possible. For now I added an option that allows the user to set the desired compression level. By default the images are stored as is.

The perf are about x10 better with this pr when packing large cbz.