### PR TITLE
fix: When converting bytes and buffers to Images we don't rely on image format guess when the extension is known

### DIFF
--- a/eco-cbz/src/cbz.rs
+++ b/eco-cbz/src/cbz.rs
@@ -5,6 +5,7 @@ use std::{
 };
 
 use camino::Utf8Path;
+use image::ImageFormat;
 use tracing::debug;
 use zip::{read::ZipFile, write::FileOptions, ZipArchive, ZipWriter};
 
@@ -243,7 +244,7 @@ where
             .format()
             .extensions_str()
             .first()
-            .ok_or(Error::UnknownImageExtension)?;
+            .ok_or(Error::UnknownImageFormatExtensions)?;
         self.insert_with_extension_and_file_options(image, extension, FileOptions::default())
     }
 
@@ -259,7 +260,7 @@ where
             .format()
             .extensions_str()
             .first()
-            .ok_or(Error::UnknownImageExtension)?;
+            .ok_or(Error::UnknownImageFormatExtensions)?;
         self.insert_with_extension_and_file_options(image, extension, file_options)
     }
 
@@ -286,7 +287,11 @@ where
     ///
     /// Same behavior as `insert_with_extension_and_file_options`
     pub fn insert_bytes_with_extension(&mut self, bytes: &[u8], extension: &str) -> Result<()> {
-        let image = bytes.try_into()?;
+        let image = Image::bytes_with_format(
+            bytes,
+            ImageFormat::from_extension(extension)
+                .ok_or_else(|| Error::InvalidImageExtension(extension.to_string()))?,
+        );
         self.insert_with_extension(image, extension)
     }
 
@@ -299,7 +304,11 @@ where
         extension: &str,
         file_options: FileOptions,
     ) -> Result<()> {
-        let image = bytes.try_into()?;
+        let image = Image::bytes_with_format(
+            bytes,
+            ImageFormat::from_extension(extension)
+                .ok_or_else(|| Error::InvalidImageExtension(extension.to_string()))?,
+        );
         self.insert_with_extension_and_file_options(image, extension, file_options)
     }
 

--- a/eco-cbz/src/errors.rs
+++ b/eco-cbz/src/errors.rs
@@ -38,8 +38,11 @@ pub enum Error {
     #[error("unknown image format error")]
     UnknownImageFormat,
 
-    #[error("unknown image extension error")]
-    UnknownImageExtension,
+    #[error("unknown image format extension error")]
+    UnknownImageFormatExtensions,
+
+    #[error("unknown image extension error: {0}")]
+    InvalidImageExtension(String),
 
     #[cfg(feature = "metadata")]
     #[error("metadata error: {0}")]

--- a/eco-cbz/src/image.rs
+++ b/eco-cbz/src/image.rs
@@ -98,6 +98,17 @@ impl<'a> Image<Cursor<&'a [u8]>> {
             format,
         })
     }
+
+    #[must_use]
+    pub fn bytes_with_format(bytes: &'a [u8], format: ImageFormat) -> Self {
+        let mut reader = ImageReader::new(Cursor::new(bytes));
+        reader.set_format(format);
+
+        Self {
+            inner: reader.into(),
+            format,
+        }
+    }
 }
 
 impl Image<Cursor<Vec<u8>>> {
@@ -114,6 +125,17 @@ impl Image<Cursor<Vec<u8>>> {
             inner: reader.into(),
             format,
         })
+    }
+
+    #[must_use]
+    pub fn buf_with_format(buf: Vec<u8>, format: ImageFormat) -> Self {
+        let mut reader = ImageReader::new(Cursor::new(buf));
+        reader.set_format(format);
+
+        Self {
+            inner: reader.into(),
+            format,
+        }
     }
 
     #[allow(clippy::missing_errors_doc)]


### PR DESCRIPTION
Fixes random "cbz error: unknown image format error" errors in Dexter